### PR TITLE
[WIP] use vehicle_angular_velocity instead of vehicle_attitude

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SIPPY"]
+	path = SIPPY
+	url = https://github.com/CPCLAB-UNIPI/SIPPY.git

--- a/install.sh
+++ b/install.sh
@@ -10,33 +10,12 @@ sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 sudo apt-get install python3.6-dev
 
 # Needed for px4tools
-sudo apt-get install libgeos-3.5.0
+sudo apt-get install libgeos-3.8.0
 sudo apt-get install libgeos-dev
-sudo pip install https://github.com/matplotlib/basemap/archive/master.zip
-
-pip3 install numpy
-pip3 install px4tools
-
-pip3 install harold
-
-# Dependencies for SIPPY
-pip3 install control
-pip3 install scipy
-# needed for slycot
-pip3 install scikit-build
-pip3 install slycot
-pip3 install future
-pip3 install matplotlib
 # Needed to be able to "show" plots by matplotlib
 sudo apt-get install python3-tk
 
 # Install SIPPY from github
-git clone https://github.com/CPCLAB-UNIPI/SIPPY.git
+git submodule update --init --recursive
 cd SIPPY
-python3 setup.py install
-# or, in case of permission error
-sudo python setup.py install
-
-# Genetic algorithm package
-pip install deap
-# or sudo pip install deap
+sudo python3 setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+numpy
+px4tools
+harold
+
+# Dependencies for SIPPY
+control
+scipy
+# needed for slycot
+scikit-build
+slycot
+future
+matplotlib
+deap
+
+-e git+https://github.com/matplotlib/basemap/archive/master.zip


### PR DESCRIPTION
Since 2 years, PX4 removed the roll/pitch/yaw rates from vehicle_attitude. With this PR we use the new uORB topics.

Some test flights resulted in this:
```
Best fit = 0.7417820116525093
Identified Transfer function:  Continuous-Time Transfer function
 1 input and 1 output

  Poles(real)    Poles(imag)    Zeros(real)    Zeros(imag)
-------------  -------------  -------------  -------------
     -3.71677        3.90951       -0.54223              0
     -3.71677       -3.90951


 [SYSID] WARNING Poor fitting 0.7417820116525093. Try different data window with more dynamics!
Not proceeding with control tuning.
```

What exactly does it want me to do?


For a log file with better fittings, we get an error at the end:
```
Best fit = 0.8441755549191987
Identified Transfer function:  Continuous-Time Transfer function
 1 input and 1 output

  Poles(real)    Poles(imag)    Zeros(real)    Zeros(imag)
-------------  -------------  -------------  -------------
     -6.11466              0       -2.41642              0
    -17.1075               0


 --------------- Finding optimal gains using Genetic Optimization ---------------
 [GA] Start of evolution
 [GA] evaluating 10 generations
 [GA] -------------------------- Generation 1 --------------------------
 [GA] -------------------------- Generation 2 --------------------------
 [GA] -------------------------- Generation 3 --------------------------
 [GA] -------------------------- Generation 4 --------------------------
 [GA] -------------------------- Generation 5 --------------------------
 [GA] -------------------------- Generation 6 --------------------------
 [GA] -------------------------- Generation 7 --------------------------
 [GA] -------------------------- Generation 8 --------------------------
 [GA] -------------------------- Generation 9 --------------------------
 [GA] -------------------------- Generation 10 --------------------------
 [GA] -- End of (successful) evolution --
optimal q [786.3392089629161, 765.43445952877, 807.7649339681285]
optimal r 477.9803354147315
Traceback (most recent call last):
  File "px4_pid_tuner.py", line 908, in <module>
    main(args)
  File "px4_pid_tuner.py", line 864, in main
    print("optimal {} rate PID gains {}".format(args["axis"], ga.get_gains()))
  File "px4_pid_tuner.py", line 775, in get_gains
    self._pid.pid_design()
  File "px4_pid_tuner.py", line 497, in pid_design
    [ self._C.dot(self._A) - (self._C.dot(self._B)).dot(Kp_bar) ]
ValueError: operands could not be broadcast together with shapes (1,2) (1,1,3)
```

Used python versions:
- numpy 1.21.2
- pandas 1.3.2
- etc